### PR TITLE
save a copy of modified electrons and photons in the miniAOD event

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
@@ -58,8 +58,10 @@ class ReducedEGProducer : public edm::stream::EDProducer<> {
  //tokens for input collections
  const edm::EDGetTokenT<reco::PhotonCollection> photonT_;
  const edm::EDGetTokenT<edm::ValueMap<reco::PhotonRef> > gsFixedPhotonMapT_;
+ const edm::EDGetTokenT<edm::ValueMap<bool> > gsFixedPhotonBoolMapT_;
  const edm::EDGetTokenT<reco::GsfElectronCollection> gsfElectronT_; 
  const edm::EDGetTokenT<edm::ValueMap<reco::GsfElectronRef> > gsFixedElectronMapT_;
+ const edm::EDGetTokenT<edm::ValueMap<bool> > gsFixedElectronBoolMapT_;
  const edm::EDGetTokenT<reco::ConversionCollection> conversionT_;
  const edm::EDGetTokenT<reco::ConversionCollection> singleConversionT_;
  
@@ -102,6 +104,8 @@ class ReducedEGProducer : public edm::stream::EDProducer<> {
  const StringCutObjectSelector<reco::GsfElectron> keepGsfElectronSel_;
  const StringCutObjectSelector<reco::GsfElectron> slimRelinkGsfElectronSel_;
  const StringCutObjectSelector<reco::GsfElectron> relinkGsfElectronSel_; 
+
+ bool keepObjectsBeforeGSFix_;
 };
 #endif
 

--- a/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 reducedEgamma = cms.EDProducer("ReducedEGProducer",
+  keepObjectsBeforeGSFix = cms.bool(True),
   keepPhotons = cms.string("hadTowOverEm()<0.15 && pt>10 && (pt>14 || chargedHadronIso()<10)"), #keep in output
   slimRelinkPhotons = cms.string("hadTowOverEm()<0.15 && pt>10 && (pt>14 || chargedHadronIso()<10)"), #keep only slimmed SuperCluster plus seed cluster
   relinkPhotons = cms.string("(r9()>0.8 || chargedHadronIso()<20 || chargedHadronIso()<0.3*pt())"), #keep all associated clusters/rechits/conversions

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -56,8 +56,10 @@ namespace std {
 ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config) :
   photonT_(consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("photons"))),
   gsFixedPhotonMapT_(consumes<edm::ValueMap<reco::PhotonRef> >(config.getParameter<edm::InputTag>("gsFixedPhotonMap"))),
+  gsFixedPhotonBoolMapT_(consumes<edm::ValueMap<bool> >(config.getParameter<edm::InputTag>("gsFixedPhotonMap"))),
   gsfElectronT_(consumes<reco::GsfElectronCollection>(config.getParameter<edm::InputTag>("gsfElectrons"))),
   gsFixedElectronMapT_(consumes<edm::ValueMap<reco::GsfElectronRef> >(config.getParameter<edm::InputTag>("gsFixedElectronMap"))),
+  gsFixedElectronBoolMapT_(consumes<edm::ValueMap<bool> >(config.getParameter<edm::InputTag>("gsFixedElectronMap"))),
   conversionT_(consumes<reco::ConversionCollection>(config.getParameter<edm::InputTag>("conversions"))),
   singleConversionT_(consumes<reco::ConversionCollection>(config.getParameter<edm::InputTag>("singleConversions"))),
   barrelEcalHits_(consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("barrelEcalHits"))),
@@ -89,7 +91,8 @@ ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config) :
   relinkPhotonSel_(config.getParameter<std::string>("relinkPhotons")),
   keepGsfElectronSel_(config.getParameter<std::string>("keepGsfElectrons")),
   slimRelinkGsfElectronSel_(config.getParameter<std::string>("slimRelinkGsfElectrons")),
-  relinkGsfElectronSel_(config.getParameter<std::string>("relinkGsfElectrons"))
+  relinkGsfElectronSel_(config.getParameter<std::string>("relinkGsfElectrons")),
+  keepObjectsBeforeGSFix_(config.getParameter<bool>("keepObjectsBeforeGSFix"))
 {  
   const std::vector<edm::InputTag>& photonidinputs = 
     config.getParameter<std::vector<edm::InputTag> >("photonIDSources");
@@ -119,6 +122,15 @@ ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config) :
   produces< reco::PhotonCoreCollection >(outPhotonCores_);
   produces< reco::GsfElectronCollection >(outGsfElectrons_);
   produces< reco::GsfElectronCoreCollection >(outGsfElectronCores_);
+
+  if (keepObjectsBeforeGSFix_) {
+    produces< reco::PhotonCollection >(outPhotons_+"BeforeGSFix");
+    produces< reco::PhotonCoreCollection >(outPhotonCores_+"BeforeGSFix");
+    produces< reco::GsfElectronCollection >(outGsfElectrons_+"BeforeGSFix");
+    produces< reco::GsfElectronCoreCollection >(outGsfElectronCores_+"BeforeGSFix");
+  }
+
+  // We still have to implement the collections below
   produces< reco::ConversionCollection >(outConversions_);
   produces< reco::ConversionCollection >(outSingleConversions_);
   produces< reco::SuperClusterCollection >(outSuperClusters_);  
@@ -152,20 +164,22 @@ ReducedEGProducer::~ReducedEGProducer()
 
 void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& theEventSetup) {
 
-  //get input collections
-  
-  
+  //get input collections  
   edm::Handle<reco::PhotonCollection> photonHandle;
   theEvent.getByToken(photonT_, photonHandle);
 
   edm::Handle<edm::ValueMap<reco::PhotonRef > > gsFixedPhotonMapHandle;
+  edm::Handle<edm::ValueMap<bool > > gsFixedPhotonBoolMapHandle;
   theEvent.getByToken(gsFixedPhotonMapT_, gsFixedPhotonMapHandle);  
+  theEvent.getByToken(gsFixedPhotonBoolMapT_, gsFixedPhotonBoolMapHandle);  
 
   edm::Handle<reco::GsfElectronCollection> gsfElectronHandle;
   theEvent.getByToken(gsfElectronT_, gsfElectronHandle);  
 
   edm::Handle<edm::ValueMap<reco::GsfElectronRef > > gsFixedElectronMapHandle;
+  edm::Handle<edm::ValueMap<bool > > gsFixedElectronBoolMapHandle;
   theEvent.getByToken(gsFixedElectronMapT_, gsFixedElectronMapHandle);  
+  theEvent.getByToken(gsFixedElectronBoolMapT_, gsFixedElectronBoolMapHandle);  
   
   edm::Handle<reco::ConversionCollection> conversionHandle;
   theEvent.getByToken(conversionT_, conversionHandle);  
@@ -217,6 +231,12 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   std::auto_ptr<reco::PhotonCoreCollection> photonCores(new reco::PhotonCoreCollection);
   std::auto_ptr<reco::GsfElectronCollection> gsfElectrons(new reco::GsfElectronCollection);
   std::auto_ptr<reco::GsfElectronCoreCollection> gsfElectronCores(new reco::GsfElectronCoreCollection);
+
+  std::auto_ptr<reco::PhotonCollection> photons_beforeGSFix(new reco::PhotonCollection);
+  std::auto_ptr<reco::PhotonCoreCollection> photonCores_beforeGSFix(new reco::PhotonCoreCollection);
+  std::auto_ptr<reco::GsfElectronCollection> gsfElectrons_beforeGSFix(new reco::GsfElectronCollection);
+  std::auto_ptr<reco::GsfElectronCoreCollection> gsfElectronCores_beforeGSFix(new reco::GsfElectronCoreCollection);
+
   std::auto_ptr<reco::ConversionCollection> conversions(new reco::ConversionCollection);
   std::auto_ptr<reco::ConversionCollection> singleConversions(new reco::ConversionCollection);
   std::auto_ptr<reco::SuperClusterCollection> superClusters(new reco::SuperClusterCollection);
@@ -250,7 +270,9 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
  
   //maps to collection indices of output objects
   std::map<reco::PhotonCoreRef, unsigned int> photonCoreMap;
+  std::map<reco::PhotonCoreRef, unsigned int> photonCoreMap_beforeGSFix;
   std::map<reco::GsfElectronCoreRef, unsigned int> gsfElectronCoreMap;
+  std::map<reco::GsfElectronCoreRef, unsigned int> gsfElectronCoreMap_beforeGSFix;
   std::map<reco::ConversionRef, unsigned int> conversionMap;
   std::map<reco::ConversionRef, unsigned int> singleConversionMap;
   std::map<reco::SuperClusterRef, unsigned int> superClusterMap;
@@ -284,8 +306,23 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     // // check if it was fixed
     // std::cout << gsFixedPhotonMapHandle->contains(gsFixedPhotonRef.id()) << std::endl;
     // std::cout << (*gsFixedPhotonMapHandle)[gsFixedPhotonRef].isNull() << std::endl;
-    reco::PhotonRef photonref = (*gsFixedPhotonMapHandle)[gsFixedPhotonRef];
-    
+    reco::PhotonRef photonref;
+    if (gsFixedPhotonMapHandle.isValid()) {
+      photonref = (*gsFixedPhotonMapHandle)[gsFixedPhotonRef];
+      if (gsFixedPhotonBoolMapHandle.isValid()) {
+	if (keepObjectsBeforeGSFix_ && (*gsFixedPhotonBoolMapHandle)[gsFixedPhotonRef]) {
+	  photons_beforeGSFix->push_back(*photonref);
+	  const reco::PhotonCoreRef &photonCore_beforeGSFix = photonref->photonCore();
+	  photonCores_beforeGSFix->push_back(*photonCore_beforeGSFix);
+	  if (!photonCoreMap_beforeGSFix.count(photonCore_beforeGSFix)) {
+	    photonCoreMap_beforeGSFix[photonCore_beforeGSFix] = photonCores_beforeGSFix->size() - 1;
+	  }
+	}
+      }
+    } else {
+      photonref = gsFixedPhotonRef;
+    }
+
     //fill pf candidate value map vector
     pfCandIsoPairVecPho.push_back((*photonPfCandMapHandle)[photonref]);
 
@@ -358,7 +395,24 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     gsfElectrons->push_back(gsfElectron);
    
     reco::GsfElectronRef gsFixedGsfElectronref(gsfElectronHandle,iele);
-    reco::GsfElectronRef gsfElectronref = (*gsFixedElectronMapHandle)[gsFixedGsfElectronref];
+    reco::GsfElectronRef gsfElectronref;
+
+
+    if (gsFixedElectronMapHandle.isValid()) {
+      gsfElectronref = (*gsFixedElectronMapHandle)[gsFixedGsfElectronref];
+      if (gsFixedElectronBoolMapHandle.isValid()) {
+	if (keepObjectsBeforeGSFix_ && (*gsFixedElectronBoolMapHandle)[gsFixedGsfElectronref]) {
+	  gsfElectrons_beforeGSFix->push_back(*gsfElectronref);
+	  const reco::GsfElectronCoreRef &gsfElectronCore_beforeGSFix = gsfElectronref->core();
+	  gsfElectronCores_beforeGSFix->push_back(*gsfElectronCore_beforeGSFix);
+	  if (!gsfElectronCoreMap_beforeGSFix.count(gsfElectronCore_beforeGSFix)) {
+	    gsfElectronCoreMap_beforeGSFix[gsfElectronCore_beforeGSFix] = gsfElectronCores_beforeGSFix->size() - 1;
+	  }
+	}
+      }
+    } else {
+      gsfElectronref = gsFixedGsfElectronref;
+    }
         
     pfCandIsoPairVecEle.push_back((*gsfElectronPfCandMapHandle)[gsfElectronref]);
     
@@ -678,7 +732,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   //put photon and gsfelectroncores into the event
   const edm::OrphanHandle<reco::PhotonCoreCollection> &outPhotonCoreHandle = theEvent.put(photonCores,outPhotonCores_);
   const edm::OrphanHandle<reco::GsfElectronCoreCollection> &outgsfElectronCoreHandle = theEvent.put(gsfElectronCores,outGsfElectronCores_);
-  
+
   //loop over photons and electrons and relink the cores
   for (reco::Photon &photon : *photons) {
     const auto &coremapped = photonCoreMap.find(photon.photonCore());
@@ -697,11 +751,39 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
       gsfElectron.setCore(coreref);
     }
   }
+
+  if (keepObjectsBeforeGSFix_) {
+    const edm::OrphanHandle<reco::PhotonCoreCollection> &outPhotonCoreHandle_beforeGSFix = theEvent.put(photonCores_beforeGSFix,outPhotonCores_+"BeforeGSFix");
+    const edm::OrphanHandle<reco::GsfElectronCoreCollection> &outgsfElectronCoreHandle_beforeGSFix = theEvent.put(gsfElectronCores_beforeGSFix,outGsfElectronCores_+"BeforeGSFix");
+
+    for (reco::Photon &photon : *photons_beforeGSFix) {
+      const auto &coremapped = photonCoreMap_beforeGSFix.find(photon.photonCore());
+      if (coremapped != photonCoreMap_beforeGSFix.end()) {
+	//make new ref
+	reco::PhotonCoreRef coreref(outPhotonCoreHandle_beforeGSFix,coremapped->second);
+	photon.setPhotonCore(coreref);
+      }
+    }
+
+    for (reco::GsfElectron &gsfElectron : *gsfElectrons_beforeGSFix) {
+      const auto &coremapped = gsfElectronCoreMap_beforeGSFix.find(gsfElectron.core());
+      if (coremapped != gsfElectronCoreMap_beforeGSFix.end()) {
+	//make new ref
+	reco::GsfElectronCoreRef coreref(outgsfElectronCoreHandle_beforeGSFix,coremapped->second);
+	gsfElectron.setCore(coreref);
+      }
+    }
+
+  }
+
   
   //(finally) store the output photon and electron collections
   const edm::OrphanHandle<reco::PhotonCollection> &outPhotonHandle = theEvent.put(photons,outPhotons_);  
   const edm::OrphanHandle<reco::GsfElectronCollection> &outGsfElectronHandle = theEvent.put(gsfElectrons,outGsfElectrons_);
-  
+  if (keepObjectsBeforeGSFix_) {
+    const edm::OrphanHandle<reco::PhotonCollection> &outPhotonsHandle_beforeGSFix = theEvent.put(photons_beforeGSFix,outPhotons_+"BeforeGSFix");
+    const edm::OrphanHandle<reco::GsfElectronCollection> &outgsfElectronsHandle_beforeGSFix = theEvent.put(gsfElectrons_beforeGSFix,outGsfElectrons_+"BeforeGSFix");
+  }  
   //still need to output relinked valuemaps
   
   //photon pfcand isolation valuemap

--- a/RecoEgamma/EgammaTools/python/egammaGainSwitchFix_cff.py
+++ b/RecoEgamma/EgammaTools/python/egammaGainSwitchFix_cff.py
@@ -1,7 +1,5 @@
 import FWCore.ParameterSet.Config as cms 
 
-bunchSpacingProducerGSFix = cms.EDProducer("BunchSpacingProducer")
-
 #this module re-makes the rec-hits using the weights reco for hits saved in ecal selected digis 
 from RecoEgamma.EgammaTools.ecalWeightRecHitFromSelectedDigis_cff import *
 #this module makes a new collection of barrel rechits where gain switched multifit crystals are swapped
@@ -24,7 +22,7 @@ from RecoEgamma.EgammaPhotonProducers.gsFixedGedPhotonCores_cfi import *
 from RecoEgamma.EgammaPhotonProducers.gsFixedGedPhotons_cfi import *
 
 egammaGainSwitchFixSequence = cms.Sequence(
-    bunchSpacingProducerGSFix*
+#    bunchSpacingProducer*
     ecalWeightLocalRecoFromSelectedDigis*
     ecalMultiAndGSWeightRecHitEB*
     gsFixedParticleFlowSuperClustering*
@@ -39,7 +37,7 @@ from RecoEgamma.EgammaElectronProducers.gsSimpleFixedGsfElectrons_cfi import gsS
 from RecoEgamma.EgammaElectronProducers.gsSimpleFixedPhotons_cfi import gsSimpleFixedPhotons
 
 egammaGainSwitchSimpleFixSequence = cms.Sequence(
-    bunchSpacingProducerGSFix*
+#    bunchSpacingProducer*
     ecalWeightLocalRecoFromSelectedDigis*
     ecalMultiAndGSWeightRecHitEB*
     gsSimpleFixedGsfElectrons*

--- a/RecoEgamma/EgammaTools/test/gsFixTest_cfg.py
+++ b/RecoEgamma/EgammaTools/test/gsFixTest_cfg.py
@@ -35,11 +35,12 @@ process.source = cms.Source ("PoolSource",fileNames = cms.untracked.vstring(
 #                                   correction is ( supercluster raw energy - E(gain switched multi fit hits) + E(gain switched weights hits) ) / supercluster raw energy
 #                                   does not correct photon H/E or R9
 
+process.load("RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi")
+process.bunchSpacingProducerSequence = cms.Sequence(process.bunchSpacingProducer)
+
 process.load("RecoEgamma.EgammaTools.egammaGainSwitchFix_cff")                                          
-process.p = cms.Path(process.egammaGainSwitchFixSequence)
+process.p = cms.Path(process.bunchSpacingProducerSequence * process.egammaGainSwitchFixSequence)
                     
-
-
 
 #dumps the products made for easier debugging, you wouldnt normally need to do this
 #edmDumpEventContent outputTest.root shows you all the products produced

--- a/RecoEgamma/EgammaTools/test/miniaod_PAT.py
+++ b/RecoEgamma/EgammaTools/test/miniaod_PAT.py
@@ -58,7 +58,7 @@ process.MINIAODoutput = cms.OutputModule("PoolOutputModule",
     overrideInputFileSplitLevels = cms.untracked.bool(True),
 )
 
-# process.MINIAODoutput.outputCommands.extend(['keep *_reducedEgamma_*BeforeGSFix_*']) 
+process.MINIAODoutput.outputCommands.extend(['keep *_reducedEgamma_*BeforeGSFix_*']) 
 
 # Additional output definition
 

--- a/RecoEgamma/EgammaTools/test/miniaod_PAT.py
+++ b/RecoEgamma/EgammaTools/test/miniaod_PAT.py
@@ -55,8 +55,10 @@ process.MINIAODoutput = cms.OutputModule("PoolOutputModule",
     fastCloning = cms.untracked.bool(False),
     fileName = cms.untracked.string('file:miniaod.root'),
     outputCommands = process.MINIAODEventContent.outputCommands,
-    overrideInputFileSplitLevels = cms.untracked.bool(True)
+    overrideInputFileSplitLevels = cms.untracked.bool(True),
 )
+
+# process.MINIAODoutput.outputCommands.extend(['keep *_reducedEgamma_*BeforeGSFix_*']) 
 
 # Additional output definition
 


### PR DESCRIPTION
Hi Sam,

I worked a bit more on the reducedEgamma producer and now it saves a copy of the GsfElectron and Photon that were modified by the fix.

We still have to work to save the correct ECAL rechits in the reduced collection